### PR TITLE
Use WikibaseQuality master instead of v1 in Travis

### DIFF
--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -21,10 +21,10 @@ rm master.tar.gz
 mv mediawiki-extensions-Wikibase-master wiki/extensions/Wikibase
 
 # checkout WikibaseQuality
-wget https://github.com/wikimedia/mediawiki-extensions-WikibaseQuality/archive/v1.tar.gz
-tar -zxf v1.tar.gz
-rm v1.tar.gz
-mv mediawiki-extensions-WikibaseQuality-1 wiki/extensions/WikibaseQuality
+wget https://github.com/wikimedia/mediawiki-extensions-WikibaseQuality/archive/master.tar.gz
+tar -zxf master.tar.gz
+rm master.tar.gz
+mv mediawiki-extensions-WikibaseQuality-master wiki/extensions/WikibaseQuality
 
 cd wiki
 


### PR DESCRIPTION
The Travis build has been failing for a week now, with the tests not finding some helper classes from the WikibaseQuality extension; I have no idea if this change will fix that, but even if it doesn’t I’m sure it’s a good idea to use the master version of the dependency instead of a tag that’s two and a half years old.

Change-Id: I3fcf26aeae5dafe7bdb7d0f599f2d33c23ed7906

---

Do not merge this pull request! I’m just submitting this on GitHub so that Travis will pick it up before merging to master, and so we can hopefully test the build early.